### PR TITLE
fixed issue where context variable was used out of scope

### DIFF
--- a/module/delete_contexts_request.js
+++ b/module/delete_contexts_request.js
@@ -34,7 +34,7 @@ DeleteContextsRequest.prototype._headers = function() {
 
 DeleteContextsRequest.prototype._requestOptions = function() {
     var request_options = DeleteContextsRequest.super_.prototype._requestOptions.apply(this, arguments);
-    var contextPath = this.context ? '/' + context : '';
+    var contextPath = this.context ? '/' + this.context : '';
 
     request_options.path = this.endpoint + 'contexts' + contextPath + '?sessionId=' + this.sessionId;
     request_options.method = 'DELETE';


### PR DESCRIPTION
When using this locally this allows me to delete context when passing a second variable.