### PR TITLE
Add support for Facebook image and video posts

### DIFF
--- a/samples/facebook/.gitignore
+++ b/samples/facebook/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 npm-debug.log
+app.yaml


### PR DESCRIPTION
Currently FB image and video messages are quietly dropped.  This PR passes such messages to API.ai for processing.  If this is a candidate for merge, then I'll follow up with the Individual and Corporate CLA's.

Please review and provide feedback.

What changes would prepare this PR for merge?