### PR TITLE
add messaging type in facebook messages

### DIFF
--- a/samples/facebook/src/app.js
+++ b/samples/facebook/src/app.js
@@ -398,6 +398,7 @@ class FacebookBot {
                 qs: {access_token: FB_PAGE_ACCESS_TOKEN},
                 method: 'POST',
                 json: {
+                    'messaging_type': 'RESPONSE',
                     recipient: {id: sender},
                     message: messageData
                 }
@@ -422,6 +423,7 @@ class FacebookBot {
                 qs: {access_token: FB_PAGE_ACCESS_TOKEN},
                 method: 'POST',
                 json: {
+                    'messaging_type': 'RESPONSE',
                     recipient: {id: sender},
                     sender_action: action
                 }


### PR DESCRIPTION
Messaging type will be mandatory 7th May 2018 - https://developers.facebook.com/docs/messenger-platform/send-messages